### PR TITLE
Added Legion Astartes v086

### DIFF
--- a/war/indexISSTVAN.html
+++ b/war/indexISSTVAN.html
@@ -12,7 +12,8 @@
 		<table id="ab">
 			<tr>
 				<td>
-					<div class="list"><a href="./chooser.html?list=30K_Legion_Astartes"><span><img class="icon" src="img/imperial_eagle.png"/></span>Legion Astartes</a></div>
+					<div class="list"><a href="./chooser.html?list=30K_Legion_Astartes_v086"><span><img class="icon" src="img/imperial_eagle.png"/></span>Legion Astartes</a></div>
+					<div class="list"><a href="./chooser.html?list=30K_Legion_Astartes"><span><img class="icon" src="img/imperial_eagle.png"/></span>Legion Astartes (old)</a></div>
 					<div class="list"><a href="./chooser.html?list=30K_Iron_Hands"><span><img class="icon" src="img/imperial_eagle.png"/></span>Iron Hands</a></div>
 					<div class="list"><a href="./chooser.html?list=30K_Salamanders"><span><img class="icon" src="img/imperial_eagle.png"/></span>Salamanders</a></div>
           <div class="list"><a href="./chooser.html?list=30K_RAVEN_GUARD"><span><img class="icon" src="img/imperial_eagle.png"/></span>Raven Guard</a></div>

--- a/war/lists/30K_Legion_Astartes_v086.json
+++ b/war/lists/30K_Legion_Astartes_v086.json
@@ -1,0 +1,191 @@
+{
+	"id":"Space Marine Legion",
+	"version":"Heresy V 0.8.6",
+	"by":"J.Barr AKA Fattdex. Updated by Mard & freefall",
+	"sections":[
+		{"name":"DETACHMENTS", "formations":[
+			{"id":500, "name":"Legion Tactical Detachment", 		"pts":275, "upgrades":[14,15,105,16,17,18,19,20,21,22,23,123,25,26,27,28,128,129,24,95,96,97,98,99]},
+			{"id":501, "name":"Legion Terminator Detachment", 		"pts":0, "upgrades":[13,21,22,23,29,31,95,96,97,98,99]},
+		    {"id":502, "name":"Legion Assault Marine Detachment",	"pts":300, "upgrades":[39,95,96,97,98,99], "units":"8 Assault Squads"},
+			{"id":503, "name":"Legion Breacher Detachment",			"pts":325, "upgrades":[14,15,105,20,21,22,23,25,26,27,28,128,129,24,123,29,30,39,95,96,97,98,99], "units":"8 Breacher Squads"}
+		 
+        ]},
+		{"name":"SUPPORT DETACHMENTS", "formations":[
+			{"id":601, "name":"Legion Space Craft",							"pts":0, "upgrades":[]},
+			{"id":603, "name":"Legion Artillery Squadron",					"pts":0, "upgrades":[24]},
+			{"id":604, "name":"Legion Assault Marine Squad",				"pts":175, "upgrades":[39,95,96,97], "units":"4 Assault Squads"},
+			{"id":605, "name":"Legion Breacher Marine Squad",   			"pts":225, "upgrades":[20,21,22,23,123,29,30,39,95,96,97]},
+            {"id":606, "name":"Legion Contemptor Dreadnought Talon",		"pts":0, "upgrades":[46,39,105]},
+			{"id":607, "name":"Legion Dreadnought Talon",					"pts":0, "upgrades":[45,39]},
+			{"id":620, "name":"Legion Leviathan Dreadnought Talon",			"pts":225, "upgrades":[39], "units":"3 Leviathan Pattern Siege Dreadnought units"},
+            {"id":621, "name":"Legion Destroyer Detachment",			    "pts":225, "upgrades":[39,95,96,97], "units":"4 Destroyer Squad units"},
+            {"id":608, "name":"Legion Javelin Attack Speeder Squadron",		"pts":275, "upgrades":[95,96,97], "units":"5 Javelin Attack Speeder units"},
+			{"id":609, "name":"Legion Land Speeder Squadron",				"pts":200, "upgrades":[95,96,97], "units":"5 Land Speeder units"},
+			{"id":623, "name":"Legion Land Raider Squadron",		        "pts":0, "upgrades":[124,125,126,24,95,96,97]},
+			
+            {"id":611, "name":"Legion Outrider Squadron",					"pts":200, "upgrades":[95,96,97]},
+			{"id":612, "name":"Legion Predator Strike Armour Squadron",		"pts":0, "upgrades":[52,53,54,55,56,24]},
+			{"id":613, "name":"Legion Rapier Weapons Battery",				"pts":240, "upgrades":[39]},
+			{"id":614, "name":"Legion Reconnaissance Squad",				"pts":150, "upgrades":[20,29,95,96,97,98,99], "units":"4 Reconnaissance Marine units"},
+			{"id":615, "name":"Legion Sicaran Battle Tank Squad",			"pts":0, "upgrades":[24,59,60]},
+			{"id":616, "name":"Legion Sky Hunter Squadron",					"pts":200, "upgrades":[95,96,97], "units":"5 Legion Jetbike units"},
+			{"id":617, "name":"Legion Storm Eagle Gunship Wing",			"pts":0, "upgrades":[61]},
+			{"id":618, "name":"Legion Thunderhawk Gunship",					"pts":250, "upgrades":[], "units":"1 Thunderhawk Gunship"},
+			{"id":619, "name":"Legion Thunderhawk Transporter",				"pts":0, "upgrades":[62]},
+            {"id":622, "name":"Legion Vindicator Squadron",				    "pts":0, "upgrades":[24,32,127]} 
+		]},
+		{"name":"ALLIES & LORDS OF WAR", "formations":[
+			{"id":712, "name":"Legion Interceptor Attack Wing ",			"pts":250, "upgrades":[], "units":"2 Xiphon Interceptor units "},
+            {"id":702, "name":"Fire Raptor Wing",							"pts":300, "upgrades":[], "units":"2 Fire Raptor Gunship units"},
+			{"id":703, "name":"Imperial Navy Primaris-Lightning Wing",		"pts":225, "upgrades":[], "units":"2 Primaris-Lightning Fighter units"},
+			{"id":704, "name":"Storm Bird",									"pts":450, "upgrades":[], "units":"1 Legion Storm Bird Heavy Gunship"},
+			{"id":705, "name":"Super Heavy Tank",							"pts":250, "upgrades":[]},
+			{"id":706, "name":"Super Heavy Tank Battery",					"pts":400, "upgrades":[]},
+			{"id":707, "name":"Super Heavy Tank Destroyer",					"pts":300, "upgrades":[], "units":"1 Falchion Unit"},
+			{"id":708, "name":"Warhound Scout Titan",						"pts":275, "upgrades":[], "units":"1 Warhound Scout Titan unit"},
+			{"id":709, "name":"Warhound Scout Titan Pack",					"pts":500, "upgrades":[], "units":"2 Warhound Scout Titan units"},
+			{"id":710, "name":"Reaver Titan",								"pts":675, "upgrades":[], "units":"1 Reaver Titan unit"},
+			{"id":711, "name":"Warlord Titan",								"pts":850, "upgrades":[], "units":"1 Warlord Titan"}
+		]}
+	],	
+	
+	"upgrades":[
+		{"id":11, "name":"8 Tactical Marines with Bolters",								"pts":0},
+		{"id":12, "name":"8 Tactical Marines with Assault Weapons",						"pts":0},
+		{"id":13, "name":"Terminators",													"pts":75},
+		{"id":14, "name":"Dreadnought: Legion Dreadnought",								"pts":50},
+		{"id":15, "name":"Dreadnought: Legion Contemptor Dreadnought",					"pts":60},
+		{"id":105, "name":"Dreadnought: Legion Deredeo Dreadnought",					"pts":100},
+        {"id":16, "name":"Support Squad: Legion Tactical Support",						"pts":25},
+		{"id":17, "name":"Support Squad: Legion Heavy Support",							"pts":25},
+		{"id":18, "name":"Rapier Battery: Rapier Laser Destroyer",						"pts":50},
+		{"id":19, "name":"Rapier Battery: Thudd Gun Units",								"pts":50},
+		{"id":20, "name":"Transport: Rhinos",											"pts":0},
+		{"id":21, "name":"Heavy Transport: Spartan Assault Tank",						"pts":125},
+		{"id":22, "name":"Heavy Transport: Land Raider Proteus",						"pts":75},
+		{"id":23, "name":"Heavy Transport: Land Raider Phobos",							"pts":75},
+		{"id":123, "name":"Heavy Transport: Mastodon",							        "pts":200},
+        {"id":24, "name":"Hyperios",													"pts":75},
+		{"id":25, "name":"Tank: Vindicator",											"pts":50},
+		{"id":26, "name":"Tank: Predator Annihilator",								"pts":60},
+		{"id":27, "name":"Tank: Predator Destructor",								"pts":60},
+		{"id":28, "name":"Tank: Sicaran",											"pts":75},
+		{"id":128, "name":"Tank: Typhon",											"pts":150},
+        {"id":129, "name":"Tank: Cerberus",											"pts":150},
+        {"id":29, "name":"Assault Claw: Kharybdis Assault Claw",						"pts":100},
+		{"id":30, "name":"Assault Ram:  Caestus Assault Ram",							"pts":75},
+		{"id":31, "name":"Teleport",													"pts":25},
+		{"id":32, "name":"Vindicator",													"pts":50},
+		
+		{"id":38, "name":"Breacher Marine",												"pts":0},
+		{"id":39, "name":"Drop Assault: Drop Pods or Dreadclaws",						"pts":50},
+		
+		{"id":40, "name":"Land Raider Phobos",											"pts":80},
+		{"id":41, "name":"Land Raider Proteus",											"pts":80},
+		{"id":42, "name":"4 Medusas",													"pts":250},
+		{"id":43, "name":"4 Whirlwinds",												"pts":300},
+		{"id":44, "name":"4 Basilisks",													"pts":325},
+		{"id":45, "name":"Legion Dreadnought",											"pts":50},
+		{"id":46, "name":"Legion Contemptor Dreadnought",								"pts":60},
+		{"id":47, "name":"3 Malcadors",													"pts":0},
+		{"id":48, "name":"3 Malcador Defenders",										"pts":0},
+		{"id":49, "name":"3 Malcador Annihilators",										"pts":0},
+		{"id":50, "name":"5 Outrider Bikes",											"pts":0},
+		{"id":51, "name":"5 Attack Bike",												"pts":0},
+		{"id":52, "name":"Predator Destructor",											"pts":60},
+		{"id":53, "name":"Predator Annihilator",										"pts":60},
+		{"id":54, "name":"Predator Infernus",											"pts":80},
+		{"id":55, "name":"Predator Support: Predator Executioner",					"pts":80},
+		{"id":56, "name":"Predator Support: Whirlwind Scorpius",						"pts":80},
+		{"id":57, "name":"6 Rapier Laser Destroyers",									"pts":0},
+		{"id":58, "name":"6 Thudd Gun units",											"pts":0},
+		{"id":59, "name":"Sicaran",														"pts":75},
+		{"id":60, "name":"Sicaran Venator",												"pts":75},
+		{"id":61, "name":"Storm Eagle Assault Gunship",									"pts":125},
+		{"id":62, "name":"Thunderhawk Transporters",									"pts":125},	
+		{"id":63, "name":"Fellblade",																	"pts":0},
+		{"id":64, "name":"Glaive",																		"pts":0},
+		{"id":65, "name":"3 Typhon Heavy Siege Tank",													"pts":0},
+		{"id":66, "name":"3 Cerberus Heavy Tank Destroyer",												"pts":0},
+		{"id":67, "name":"Strike Cruiser",												"pts":200},
+		{"id":68, "name":"Battle Barge",												"pts":300},
+		
+		
+	
+		{"id":93, "name":"Terminators",													"pts":0},
+		{"id":94, "name":"Legion Primarch",									"pts":0},
+		{"id":95, "name":"Centurion: Librarian",							"pts":50},
+		{"id":96, "name":"Centurion: Chaplain",								"pts":50},
+		{"id":97, "name":"Centurion: Legion Champion",						"pts":50},
+		{"id":98, "name":"Praetor: Lieutenant Commander",					"pts":50},
+		{"id":99, "name":"Praetor: Lord Commander",							"pts":100},
+		{"id":124, "name":"Land Raider Proteus",						"pts":80},
+        {"id":125, "name":"Land Raider Phobos",						"pts":80},
+        {"id":126, "name":"Land Raider Achilles",						"pts":105},
+		{"id":127, "name":"Vindicator Laser Destroyer",					"pts":70}
+
+		
+	],
+	"formationConstraints":[
+		{"max":3, "name":"Support Detachment", "from":[601,603,604,605,606,607,608,609,611,612,613,614,615,616,617,618,619,620,621,622], "forEach":[500,501,502,503], "name2":"Detachment"},
+		{"maxPercent":33, "name":"ALLIES & LORDS OF WAR", "from":[702,703,704,705,706,707,708,709,710,711,712]},
+		{"max":1, "from":[601]}
+	],
+	"upgradeConstraints":[
+		{"min":0, "max":1, "from":[95,96,97,98,99], "appliesTo":[500,501,502,503]},
+		{"min":0, "max":1, "from":[98,99], "appliesTo":[]},
+		{"min":0, "max":1, "from":[95,96,97], "appliesTo":[602,603,604,608,609,611,614,616,605,621]},
+		
+		{"min":1, "max":1, "from":[11,12], "appliesTo":[500]},
+		{"min":0, "max":2, "from":[14,15,105], "appliesTo":[500,503]},
+		{"min":0, "max":3, "from":[21,123], "appliesTo":[500,503]},
+		{"min":0, "max":6, "from":[22,23], "appliesTo":[500,503]},
+		{"min":0, "max":4, "from":[18,19], "appliesTo":[500]},
+		{"min":0, "max":4, "from":[16,17], "appliesTo":[500]},
+		{"min":0, "max":2, "from":[25,26,27,28,128,129], "appliesTo":[500,503]},
+		
+		{"min":4, "max":6, "from":[13], "appliesTo":[501]},
+		{"min":0, "max":3, "from":[21], "appliesTo":[501]},
+		{"min":0, "max":6, "from":[22,23], "appliesTo":[501]},
+		{"min":0, "max":3, "from":[29], "appliesTo":[501,503]},
+		
+		
+		{"min":1, "max":1, "from":[42,43,44], "appliesTo":[603]},
+		
+        {"min":0, "max":1, "from":[39], "appliesTo":[502,503,604,606,607,613,620,621]},
+
+		{"min":4, "max":4, "from":[38], "appliesTo":[605]},
+		{"min":0, "max":2, "from":[30], "appliesTo":[605]},
+		{"min":0, "max":2, "from":[22,23], "appliesTo":[605]},
+		{"min":0, "max":1, "from":[21], "appliesTo":[605]},
+		{"min":4, "max":6, "from":[45], "appliesTo":[607]},
+		{"min":4, "max":6, "from":[46,105], "appliesTo":[606]},
+		{"min":0, "max":2, "from":[105], "appliesTo":[606]},
+        {"min":1, "max":1, "from":[50,51], "appliesTo":[611]},
+		
+		{"min":4, "max":6, "from":[52,53,54,55,56], "appliesTo":[612]},
+		{"min":0, "max":2, "from":[54,55,56], "appliesTo":[612]},
+		{"min":1, "max":1, "from":[57,58], "appliesTo":[613]},
+		{"min":0, "max":1, "from":[29], "appliesTo":[614]},
+		{"min":4, "max":6, "from":[59,60], "appliesTo":[615]},
+		
+        {"min":1, "max":3, "from":[61], "appliesTo":[617]},
+		{"min":1, "max":3, "from":[62], "appliesTo":[619]},
+		{"min":4, "max":6, "from":[32,127], "appliesTo":[622]},
+		{"min":0, "max":2, "from":[127], "appliesTo":[622]},
+		
+		{"min":1, "max":1, "from":[63,64], "appliesTo":[705]},
+		{"min":1, "max":1, "from":[65,66], "appliesTo":[706]},
+		
+     	{"min":1, "max":1, "from":[67,68], "appliesTo":[601]},
+		{"min":4, "max":6, "from":[124,125,126], "appliesTo":[623]},
+        {"min":0, "max":2, "from":[126], "appliesTo":[623]},
+
+		{"max":1, "from":[20]},
+		{"max":1, "from":[24]},
+		{"max":1, "from":[31]},
+		{"max":1, "perArmy":true, "from":[99,94]}
+	
+				
+	]
+}


### PR DESCRIPTION
, since this version is not backward compatible the old version is kept. Especially regarding the fact that 'generic' primarch profile is removed from the list