### PR TITLE
Price break for upgrades, sample implementation for Imperial Fists

### DIFF
--- a/war/js/ArmyList.js
+++ b/war/js/ArmyList.js
@@ -3,15 +3,15 @@ var ArmyList = {
 	data:{},
 	allFormations:[],
 	allNonFixedFormations:[],
-	init:function(input) {		
+	init:function(input) {
 
 		this.data = input;
 		this.allNonFixedFormations = input.sections.pluck('formations').flatten();
 		this.allFormations = input.fixedFormations ? input.fixedFormations.concat( this.allNonFixedFormations )
 														  		 : this.allNonFixedFormations;
-			
+
 		// FORMATION UPGRADES...
-		this.allFormations.each( function(formation) {	
+		this.allFormations.each( function(formation) {
 			// fill in empty upgrade lists
 			if (!formation.upgrades) formation.upgrades = [];
 
@@ -35,7 +35,7 @@ var ArmyList = {
 			// set some useful properties and defaults
 			if (!constraint.min && constraint.max) constraint.min = 0;
 			if (constraint.min && !constraint.max) constraint.max = 1000000;
-                        if (!constraint.name && constraint.perPoints) constraint.name = constraint.from[0].name;                         
+                        if (!constraint.name && constraint.perPoints) constraint.name = constraint.from[0].name;
 			constraint.mandatory = constraint.min && !constraint.perArmy;
 			constraint.mandatoryWithOptions = constraint.mandatory && constraint.from.length > 1;
 		});
@@ -51,7 +51,7 @@ var ArmyList = {
 			// set some useful properties and defaults
                         if (!constraint.min && constraint.max) constraint.min = 0;
 			if (constraint.min && !constraint.max) constraint.max = 1000000;
-                        if (!constraint.name && constraint.perPoints) constraint.name = constraint.from[0].name; 
+                        if (!constraint.name && constraint.perPoints) constraint.name = constraint.from[0].name;
 		});
 
 		// FORMATIONS... add some useful properties/functions...
@@ -67,7 +67,7 @@ var ArmyList = {
 			});
 
 			// upgrade constraints...
-			formation.upgradeConstraints = 
+			formation.upgradeConstraints =
 				ArmyList.data.upgradeConstraints.filter( function(x){
 					return x.appliesTo.member(formation);
 				});
@@ -75,7 +75,7 @@ var ArmyList = {
 				formation.upgradeConstraints.filter( function(x){
 					return x.mandatory;
 				});
-			formation.mandatoryConstraint = function(upgrade){		
+			formation.mandatoryConstraint = function(upgrade){
 				return formation.mandatoryUpgradeConstraints.find( function(constraint){
 						return constraint.from.member(upgrade);
 					});
@@ -99,12 +99,18 @@ var ArmyList = {
 					}
 				});
 				return defaults;
-			};		
+			};
 			// cost including any mandatory upgrades... add them in too!
 			var total = 0;
 			formation.mandatoryUpgradeConstraints.each( function(x) {
-				total += x.min * x.from[0].pts;
-			});		
+				if (Array.isArray(x.from[0].pts)) {
+					for(var i=0; i < x.min; i++) {
+						total += x.from[0].pts[i % x.from[0].pts.length];
+					}
+				} else {
+					total += x.min * x.from[0].pts;
+				}
+			});
 			formation.cost = formation.pts + total;
 		});
 	},
@@ -132,7 +138,7 @@ var ArmyList = {
             }
             return x;
         },
-	violated:function(pts,formations,constraint) {		
+	violated:function(pts,formations,constraint) {
 		if (constraint.perPoints && constraint.max) {
                         var slots = ArmyList.roundUp(pts,constraint.perPoints) / constraint.perPoints;
 			var tooMany = formations.countAll(constraint.from) > slots * constraint.max;
@@ -142,7 +148,7 @@ var ArmyList = {
                         var slots = ArmyList.roundUp(pts,constraint.perPoints) / constraint.perPoints;
                         var tooFew = formations.countAll(constraint.from) < slots * constraint.min;
 			if (tooFew) return 'less than ' +constraint.min+ ' ' +constraint.name+ ' per ' +constraint.perPoints+ ' points';
-		}		
+		}
 		if (constraint.forEach && constraint.max) {
 			var tooMany = formations.countAll(constraint.from) > formations.countAll(constraint.forEach) * constraint.max;
 			if (tooMany) return 'more than ' +constraint.max+' '+constraint.name+ ' per ' +constraint.name2;
@@ -186,5 +192,3 @@ var ArmyList = {
             return mandatoryFormations;
         }
 };
-
-

--- a/war/js/Force.js
+++ b/war/js/Force.js
@@ -20,10 +20,19 @@ var Force = {
 								},
 								calcPoints:function() {
 									var total = this.type.pts;
+									var counted = {}
+
 									this.upgrades.each(function(u) {
-										total += u.pts;
+											if (Array.isArray(u.pts)) {
+												counted[u.name] = counted[u.name] == undefined ? 0 : counted[u.name] + 1;
+												total += u.pts[counted[u.name] % u.pts.length];
+											}
+											else {
+												total += u.pts;
+											}
 									});
-									return total;				
+
+									return total;
 								},
 								canRemove:function(upgradeType) {
 									// check minimum constraint
@@ -31,8 +40,8 @@ var Force = {
 									if (constraint) {
 										var total = this.upgrades.countAll( constraint.from );
 										return total > constraint.min;
-									}	
-									return true;								
+									}
+									return true;
 								},
 								cannotAdd:function(upgradeType) {
 									var why = [];
@@ -40,7 +49,7 @@ var Force = {
 									var allUpgrades = Force.allUpgrades();
 									this.type.constraintsOn(upgradeType).each( function(c) {
 										why.push( ArmyList.canAddUpgrade( c.perArmy ? allUpgrades : upgrades, c ) );
-									});										
+									});
 									return why.without('');
 								},
 								cannotSwap:function(upgradeType,swapType) {
@@ -49,11 +58,11 @@ var Force = {
 									var allUpgrades = Force.allUpgrades().remove( upgradeType );
 									this.type.constraintsOn(swapType).each( function(c) {
 										why.push( ArmyList.canAddUpgrade( c.perArmy ? allUpgrades : upgrades, c ) );
-									});										
+									});
 									return why.without('');
 								}
 							};
-		this.formations.push( formation );			
+		this.formations.push( formation );
 		return formation;
 	},
 	getWarnings:function(){
@@ -96,7 +105,7 @@ var Force = {
 			x.upgrades.uniq().each( function(u) {
 				out += '~' + u.id + 'x' + x.count(u);
 			});
-		});	
+		});
 		return out;
 	},
 	unpickle:function(pickled) {
@@ -113,14 +122,14 @@ var Force = {
 						currentFormation = Force.addFormation( ArmyList.formationForId(id), true );
 					}
 					else {
-						var count = parseInt(x.split('x')[1]);			
+						var count = parseInt(x.split('x')[1]);
 						for (var i=0;i<count;i++) {
 							currentFormation.upgrades.push( ArmyList.upgradeForId(id) );
 						}
 					}
-				}			
+				}
 			});
-			return name;	
+			return name;
 		}
 		catch(err) {
 			alert('Sorry, there was an error loading the army.');
@@ -145,5 +154,3 @@ var Force = {
 		return txt;
 	}
 };
-
-

--- a/war/lists/SM_impfists_NETEA.json
+++ b/war/lists/SM_impfists_NETEA.json
@@ -2,20 +2,20 @@
         "id":"Imperial Fists",
         "version":"NetEA V1.3 - Developmental",
         "by":"Kyussinchains",
-        
+
         "notes":["Some formations include plus transport in their core units. When stated the following rules apply. 1)The formation may take sufficent Rhinos to transport it once other upgrades with transports have been purchased. 2) When both Land Raiders and Razorbacks are available the following process should be followed. Purchase up to the max allowed Land Raiders. Add any Rhinos as per the plus transport option. Replace each each rhino with up to 2 Razorbacks per rhino up to the maximum allowed Razorbacks, 3) A formation may exchange its 'plus transport' for 50cm x 2.5cm of minefields, trenches or razorwire and 2 bunkers for free "],
         "sections":[
                 {"name":"DETACHMENTS", "formations": [
-                        { "id":501, "name":"Centurion",                                                 "pts":0, "upgrades":[22,43,41,50,51,52,42,53,54,55] },
-                        { "id":502, "name":"Devastator",                                                "pts":250, "units":"4 Devastator units", "upgrades":[11,12,13,14,16,17,20,21,22,43,41,50,51,52,42,53,54,55,47,56,48,49,60,61,62]},
-                        { "id":507, "name":"Land Raiders",                                              "pts":325, "upgrades":[11,12,13,14,15,16,22,43] },
+                        { "id":501, "name":"Centurion",                                                 "pts":0, "upgrades":[22,41,42] },
+                        { "id":502, "name":"Devastator",                                                "pts":250, "units":"4 Devastator units", "upgrades":[11,12,13,14,16,17,20,21,22,41,42,47,48,49,60,61,62]},
+                        { "id":507, "name":"Land Raiders",                                              "pts":325, "upgrades":[11,12,13,14,15,16,22] },
                         { "id":508, "name":"Land Speeders",                                     "pts":200, "upgrades":[11,12,13,14] },
-                        { "id":511, "name":"Predators",                                                 "pts":250, "upgrades":[11,12,13,16,22,43]},
-                        { "id":503, "name":"Scouts", "units":"4 Scout units",            "pts":150, "upgrades":[11,12,13,14,17,20,21,22,43,46,60,61,62] },
-                        { "id":504, "name":"Tactical", "units":"6 Tactical units",       "pts":275, "upgrades":[11,12,13,14,16,17,20,21,22,43,41,50,51,52,42,53,54,55,47,56,48,49,60,61,62] },
-                        { "id":505, "name":"Terminators", "units":"4 Terminator units",         "pts":325, "upgrades":[11,12,13,14,17,22,43,41,50,51,52,42,53,54,55] },
+                        { "id":511, "name":"Predators",                                                 "pts":250, "upgrades":[11,12,13,16,22]},
+                        { "id":503, "name":"Scouts", "units":"4 Scout units",            "pts":150, "upgrades":[11,12,13,14,17,20,21,46,60] },
+                        { "id":504, "name":"Tactical", "units":"6 Tactical units",       "pts":275, "upgrades":[11,12,13,14,16,17,20,21,22,41,42,47,48,49,60,61,62] },
+                        { "id":505, "name":"Terminators", "units":"4 Terminator units",         "pts":325, "upgrades":[11,12,13,14,17,22,41,42] },
                         { "id":506, "name":"Thunderfire Battery",                               "pts":250, "units":"4 Thunderfire Cannons", "upgrades":[15,17] },
-                        { "id":509, "name":"Vindicator", "units":"4 Vindicators",                          "pts":225, "upgrades":[11,12,13,14,16,22,43] },
+                        { "id":509, "name":"Vindicator",                          "pts":75, "upgrades":[11,12,13,14,16,22] },
                         { "id":510, "name":"Whirlwind Battery", "units":"4 Whirlwinds",                    "pts":300, "upgrades":[11,12,13,14,16,23] },
                         { "id":512, "name":"Fellblade", "units":"1 Fellblade",  "pts":325, "upgrades":[] },
                         { "id":513, "name":"Bastion", "units":"1 Bastion",        "pts":200, "upgrades":[15,48,49,70] }
@@ -46,11 +46,11 @@
                { "id":60, "name":"Rhino", "pts":0 },
                { "id":61, "name":"2 Bunkers + Minefields", "pts":0 },
                { "id":62, "name":"2 Bunkers + Trenches", "pts":0 },
-               
+
                 { "id":18, "name":"Land Speeder Tornado", "pts":0 },
                 { "id":19, "name":"Land Speeder Typhoon", "pts":10 },
                 { "id":30, "name":"Land Raider Crusader", "pts":0 },
-                { "id":22, "name":"Vindicator", "pts":50 },
+                { "id":22, "name":"Vindicator", "pts":[50, 25] },
                 { "id":23, "name":"2 Whirlwinds", "pts":125 },
                 { "id":17, "name":"Dreadnought", "pts":50 },
                 { "id":27, "name":"Land speeder", "pts":0 },
@@ -60,17 +60,10 @@
                 { "id":24, "name":"Land Raider", "pts":0 },
                 { "id":40, "name":"Land Raider Achilles", "pts":25 },
                 { "id":26, "name":"Land Raider", "pts":0 },
-                { "id":41, "name":"Land Raider", "pts":75 },
-				{ "id":50, "name":"2 Land Raiders", "pts":125 },
-				{ "id":51, "name":"3 Land Raiders", "pts":200 },
-				{ "id":52, "name":"4 Land Raiders", "pts":250 },
-                { "id":42, "name":"Land Raider Crusader", "pts":75 },
-				{ "id":53, "name":"2 Land Raider Crusaders", "pts":125 },
-				{ "id":54, "name":"3 Land Raider Crusaders", "pts":200 },
-				{ "id":55, "name":"4 Land Raider Crusaders", "pts":250 },
-                { "id":47, "name":"Land Raider Achilles", "pts":100 },
-				{ "id":56, "name":"2 Land Raider Achilles", "pts":175 },
-                { "id":43, "name":"2 Vindicators", "pts":75 },
+                { "id":41, "name":"Land Raider", "pts": [75, 50] },
+
+                { "id":42, "name":"Land Raider Crusader", "pts":[75, 50] },
+			          { "id":47, "name":"Land Raider Achilles", "pts":[100, 175] },
                 { "id":44, "name":"Assault Centurion", "pts":75 },
                 { "id":45, "name":"Devastator Centurion","pts":75 },
                 { "id":46, "name":"Snipers","pts":50 },
@@ -87,36 +80,29 @@
         "upgradeConstraints":[
                 {"max":1, "perArmy":true, "from":[14]},
                 {"max":1, "name":"Commander", "from":[11,12,13,14,15]},
-               
-                {"max":1, "from":[22,43]},
+
+                {"max":2, "from":[22], "appliesTo": [501,502,504,505,507,511]},
                 {"max":1, "from":[60,61,62,63]},
                 {"max":2, "from":[25]},
                 {"max":4, "from":[48,49]},
           {"max":4, "from":[70], "appliesTo":[513]},
                 {"max":1, "from":[16]},
                 {"max":2, "from":[17]},
-                
+
                 {"max":2, "from":[22], "appliesTo":[502,503,507]},
                 {"max":1, "from":[23]},
                 {"max":2, "from":[40]},
-                {"max":1, "from":[47,56]},
-                {"max":1, "from":[41,50,51,52]},
-				{"max":1, "from":[42,53,54,55]},
-				
-				{"max":1, "from":[56,51,52,54,55], "appliesTo":[501,502,504]},
-				{"max":1, "from":[47,52,55], "appliesTo":[502,504]},
-				{"max":1, "from":[52,42,53,54,55], "appliesTo":[501,502,504,505]},
-				{"max":1, "from":[51,53,54,55], "appliesTo":[501,502,504,505]},
-				{"max":1, "from":[50,54,55], "appliesTo":[501,502,504,505]},
-				{"max":1, "from":[41,55], "appliesTo":[501,502,504,505]},
+                {"max":2, "from":[47]},
+                {"max":4, "from":[41,42]},
+
+                {"min": 4, "max": 6, "from": [22], "appliesTo": [509]},
+
                 {"min":4, "max":4, "from":[44,45], "appliesTo":[501]},
                 {"min":4, "max":4, "from":[24,30,40], "appliesTo":[507]},
                 {"max":2, "from":[40], "appliesTo":[507]},
                 {"min":4, "max":4, "from":[37,38], "appliesTo":[511]},
                 {"min":5, "max":5, "from":[27,18,19], "appliesTo":[508]}
-               
-               
+
+
         ]
 }
-
-


### PR DESCRIPTION
Feature added to Armyforge: upgrades can have price specified as an array ("pts": [75, 50]). When applying the upgrade every second unit would cost 50 instead of 75 points. Array can be of any length, e.g. three elements [25,25,10] would mean that the first and second (as well as fourth, fifth etc,) would cost 25 points and the third, sixth, etc. would cost 10 points.

Updated the Imperial Fist army list to take advantage of this new feature for Vindicator and Land Raider upgrades 