### PR TITLE
Update IG_steelLegion_NETEA.json

### DIFF
--- a/war/lists/IG_steelLegion_NETEA.json
+++ b/war/lists/IG_steelLegion_NETEA.json
@@ -4,16 +4,16 @@
 	"by":"Kyussinchains",
 	"sections":[
 		{"name":"COMPANIES", "formations":[
-			{"id":512, "name":"Regimental HQ", 			"pts":500, "upgrades":[26,27,28,29,30,31,32,33,37,34,35], "units":"Supreme Commander, 12 Infantry, 7 Chimera"},
-			{"id":513, "name":"Infantry Company", 			"pts":250, "upgrades":[26,27,28,29,30,31,32,33,37,34,35], "units":"Commander, 12 Infantry"},
-			{"id":514, "name":"Mechanised Infantry Company", 	"pts":400, "upgrades":[26,27,28,29,30,31,32,33,37,34,35], "units":"Commander, 12 Infantry, 7 Chimera"},
-			{"id":515, "name":"Tank Company", 			"pts":650, "upgrades":[26,27,28,29,30,31,32,33,37,34,35]},
-			{"id":516, "name":"Super-Heavy Tank Company", 		"pts":500, "upgrades":[26,27,28,29,30,31,32,33,37,34,35]},
-		 	{"id":517, "name":"Artillery Company", 			"pts":600, "upgrades":[26,27,28,29,30,31,32,33,37,34,35]}
+			{"id":512, "name":"Regimental HQ", 			"pts":475, "upgrades":[26,27,28,29,30,31,32,33,34,35], "units":"Supreme Commander, 12 Infantry, 7 Chimera"},
+			{"id":513, "name":"Infantry Company", 			"pts":250, "upgrades":[26,27,28,29,30,31,32,33,34,35], "units":"Commander, 12 Infantry"},
+			{"id":514, "name":"Mechanised Infantry Company", 	"pts":400, "upgrades":[26,27,28,29,30,31,32,33,34,35], "units":"Commander, 12 Infantry, 7 Chimera"},
+			{"id":515, "name":"Tank Company", 			"pts":650, "upgrades":[26,27,28,29,30,31,32,33,34,35]},
+			{"id":516, "name":"Super-Heavy Tank Company", 		"pts":500, "upgrades":[26,27,28,29,30,31,32,33,34,35]},
+		 	{"id":517, "name":"Artillery Company", 			"pts":550, "upgrades":[26,27,28,29,30,31,32,33,34,35]}
 		]},
 		{"name":"SUPPORT FORMATIONS", "formations":[
 			{"id":500, "name":"Rough Rider Platoon", 			"pts":150, "upgrades":[], "units":"6 Rough Riders"},
-			{"id":501, "name":"Storm Trooper Platoon",			"pts":200, "upgrades":[36], "units":"8 Storm Troopers"},
+			{"id":501, "name":"Storm Trooper Platoon",			"pts":200, "upgrades":[36,38], "units":"8 Storm Troopers"},
 			{"id":502, "name":"Artillery Battery",				"pts":250, "upgrades":[]},
 			{"id":505, "name":"Sentinel Squadron",				"pts":100, "upgrades":[], "units":"4 Sentinels"},
 			{"id":506, "name":"Deathstrike Missile Battery",		"pts":200, "upgrades":[], "units":"2 Deathstrike Missile Launchers"},
@@ -21,10 +21,12 @@
 			{"id":508, "name":"Orbital Support",				"pts":150, "upgrades":[]},
 			{"id":509, "name":"Flak Battery",				"pts":150, "upgrades":[], "units":"3 Hydra"},
 			{"id":510, "name":"Vulture Squadron",				"pts":300, "upgrades":[], "units":"4 Vultures"}
+			{"id":511, "name":"Basilisk Battery",				"pts":225, "upgrades":[], "units":"3 Basilisks"}
 		]},
 		{"name":"IMPERIAL NAVY", "formations":[
 			{"id":519, "name":"Thunderbolt Fighters",	"pts":150, "upgrades":[], "units":"2 Thunderbolts"},
 			{"id":520, "name":"Marauder Bombers",		"pts":250, "upgrades":[], "units":"2 Marauders"}
+			{"id":529, "name":"Orbital support",		"pts":150, "upgrades":[]},
 		]},
 		{"name":"TITAN LEGIONS", "formations":[
 			{"id":522, "name":"Warlord Class Titan",	"pts":825, "upgrades":[]},
@@ -52,26 +54,29 @@
 		{"id":28, "name":"Infantry Platoon (6 Infantry)",		"pts":100},
 		{"id":29, "name":"Tank Squadron (3 Leman Russ)",		"pts":175},
 		{"id":30, "name":"Tank Squadron (3 Demolishers)",		"pts":175},
-		{"id":31, "name":"Hellhound Squadron (3 Hellhounds)",		"pts":100},
+		{"id":31, "name":"Hellhound",					"pts":25},
 		{"id":32, "name":"Griffon Battery (3 Griffons)",		"pts":50},
-		{"id":33, "name":"1 Sniper",					"pts":25},
-		{"id":37, "name":"2 Snipers",					"pts":50},
-		{"id":34, "name":"2 Ogryns",					"pts":50},
+		{"id":33, "name":"Sniper",					"pts":25},
+		{"id":34, "name":"Ogryn",					"pts":25},
 		{"id":35, "name":"Hydra",					"pts":50},
 		{"id":36, "name":"Valkyrie Transport",				"pts":150}
+		{"id":38, "name":"Chimera Transport",				"pts":100}
+		{"id":50, "name":"Lunar Class Cruiser",				"pts":0}
+		{"id":51, "name":"Emperor Class Battleship",			"pts":0}
 	],
 	"formationConstraints":[
-		{"max":2, "name":"Support Formations", "from":[500,501,502,505,506,507,508,509,510], "forEach":[512,513,514,515,516,517], "name2":"Company"},
+		{"max":2, "name":"Support Formations", "from":[500,501,502,505,506,507,508,509,510,511], "forEach":[512,513,514,515,516,517], "name2":"Company"},
 		{"maxPercent":33, "name":"Titans & Navy", "from":[519,520,522,523,524,526]},
 		{"max":1, "from":[508]},
 		{"max":1, "from":[506]},
 		{"max":1, "from":[512]}
+		{"max":1, "from":[529]}
 
 	],
 	"upgradeConstraints":[
 		{"min":10, "max":10, "from":[11,12], "appliesTo":[515]},
 		{"min":3, "max":3, "from":[14,15], "appliesTo":[516]},
-    {"min":1, "max":1, "from":[41,42,43], "appliesTo":[502]},
+ 		{"min":1, "max":1, "from":[42,43], "appliesTo":[502]},
 		{"min":1, "max":1, "from":[14,15], "appliesTo":[507]},
 		{"min":9, "max":9, "from":[20,21], "appliesTo":[517]},
 		{"min":1, "max":1, "from":[23,24], "appliesTo":[508]},
@@ -81,11 +86,11 @@
 		{"max":1, "from":[28]},
 		{"max":1, "from":[29]},
 		{"max":1, "from":[30]},
-		{"max":1, "from":[31]},
+		{"max":3, "from":[31]},
 		{"max":1, "from":[32]},
-		{"max":1, "from":[33,37]},
-		{"max":1, "from":[34]},
+		{"max":1, "from":[33]},
+		{"max":2, "from":[34]},
 		{"max":1, "from":[35]},
-		{"max":1, "from":[36]}
+		{"max":1, "from":[36,38]}
 	]
 }


### PR DESCRIPTION
Updated as in Net EA Tournament pack:
> Orgyn upgrade changes to 1 or 2 at 25pts each
> Artillary Company points decreased by 50 pts
> Mechanized HQ Infantry Company reduced by 25 pts
> Hellhound upgrade reduced by 25 pts
> Storm troopers allowed to take chimera transport
> Basilisk battery reduced by 25 pts
> Emperor Class Battleship reduced by 50 pts

I hope I didn't mess anything up and everything will work as intended.