### PR TITLE
Fix formation IDs

### DIFF
--- a/war/js/Force.js
+++ b/war/js/Force.js
@@ -118,9 +118,13 @@ var Force = {
 				}
 				else {
 					var id = parseInt(x.split('x')[0]);
-					if (id >= 500) {
+					// Explicitly check whether the ID is intended to represent a formation or an upgrade.
+					// Historically it was assumed id >= 500 was a formation, but this constraint is only enforced on load not on creation.
+					// This meant some lists had formation IDs < 500 which consequently didn't load.
+					var f = ArmyList.formationForId(id);
+					if (id >= 500 || f != null) {
 						console.log('Adding formation with ID: '+id);
-						currentFormation = Force.addFormation( ArmyList.formationForId(id), true );
+						currentFormation = Force.addFormation(f , true );
 					}
 					else {
 						console.log('Adding upgrade with ID: '+id);

--- a/war/js/Force.js
+++ b/war/js/Force.js
@@ -119,9 +119,11 @@ var Force = {
 				else {
 					var id = parseInt(x.split('x')[0]);
 					if (id >= 500) {
+						console.log('Adding formation with ID: '+id);
 						currentFormation = Force.addFormation( ArmyList.formationForId(id), true );
 					}
 					else {
+						console.log('Adding upgrade with ID: '+id);
 						var count = parseInt(x.split('x')[1]);
 						for (var i=0;i<count;i++) {
 							currentFormation.upgrades.push( ArmyList.upgradeForId(id) );
@@ -132,6 +134,7 @@ var Force = {
 			return name;
 		}
 		catch(err) {
+			console.log(err);
 			alert('Sorry, there was an error loading the army.');
 		}
 	},


### PR DESCRIPTION
Remove assumption made by the list loader that formation IDs are >= 500, to fix bug affecting NetEA Saim Hann:
https://www.tacticalwargames.net/taccmd/viewtopic.php?p=641821#p641821

This PR includes commits from previous PR to improve logging,