### PR TITLE
Update SM_codex_NETEA.json

### DIFF
--- a/war/lists/SM_codex_NETEA.json
+++ b/war/lists/SM_codex_NETEA.json
@@ -1,17 +1,17 @@
 {
 	"id":"Codex Astartes",
-	"version":"NetEA Tournament Pack 2018",
-	"by":"lindstrom, latest edit 23-08-2018 Kyrt",
-  "notes":["The Thunderhawk counts towards the 1/3 points limit, but other Space Marine Fleet units do not"],
+	"version":"NetEA Tournament Pack 2022",
+	"by":"lindstrom, latest edit 14-12-2022 Abetillo",
+  "notes":["Thunderhawks counts towards the 1/3 points limit, but other Space Marine Fleet units do not"],
 
 	"sections":[
 		{"name":"SPACE MARINE DETACHMENTS", "formations":[
-			{"id":543, "name":"Tactical",		"pts":275, "units":"6 Tacticals", "upgrades":[15,16,17,18,26,21,22,23,27,31,32,11,12]},
+			{"id":543, "name":"Tactical",		"pts":275, "units":"6 Tacticals plus transport", "upgrades":[15,16,17,18,26,28,20,21,22,23,27,31,32,11,12]},
 			{"id":532, "name":"Assault", 		"pts":175, "units":"4 Assault Units", "upgrades":[15,16,17,18,31,32]},
-			{"id":534, "name":"Devastator",		"pts":250, "units":"4 Devastators", "upgrades":[15,16,17,18,26,21,22,23,27,11,12]},
+			{"id":534, "name":"Devastator",		"pts":250, "units":"4 Devastators plus transport", "upgrades":[15,16,17,18,26,28,20,21,22,23,27,11,12]},
 			{"id":533, "name":"Bike", 			"pts":200, "upgrades":[15,16,17,18]},
-			{"id":539, "name":"Scout",			"pts":150, "upgrades":[15,16,17,18,26,11,12]},
-			{"id":544, "name":"Terminator",		"pts":350, "units":"4 Terminators", "upgrades":[15,16,17,18,31,32,21,23,27]},
+			{"id":539, "name":"Scout",			"pts":150, "units":"4 Scout units plus transport", "upgrades":[15,16,17,18,26,28,11,12]},
+			{"id":544, "name":"Terminator",		"pts":350, "units":"4 Terminators", "upgrades":[15,16,17,18,20,21,31,32,23,27]},
 			{"id":535, "name":"Land Raider",			"pts":325, "units":"4 Land Raiders", "upgrades":[15,16,17,18,22,31,32]},
 			{"id":536, "name":"Land Speeder",			"pts":200, "upgrades":[15,16,17,18]},
 			{"id":538, "name":"Predator",				"pts":250, "upgrades":[15,16,17,18,22,31,32]},
@@ -51,19 +51,20 @@
 		{"id":17, "name":"Librarian", 		"pts":50},
 		{"id":18, "name":"Supreme Commander",	"pts":100},
 
-		{"id":21, "name":"Dreadnought", 					"pts":50},
+		{"id":20, "name":"Dreadnought (Power Fist config.)", 			"pts":50},
+		{"id":21, "name":"Dreadnought (Hellfire config.)", 			"pts":50},
 		{"id":22, "name":"Hunter", 						"pts":75},
 		{"id":23, "name":"Land Raider", 					"pts":75},
 		{"id":27, "name":"2x Land Raider", 					"pts":125},
-		{"id":26, "name":"Razorback",						"pts":25},
-		{"id":40, "name":"Scouts",						"pts":0},
-		{"id":41, "name":"Scout Snipers",						"pts":10},
+		{"id":26, "name":"Razorback (Twin Laser Canon)",			"pts":25},
+		{"id":28, "name":"Razorback (Twin Heavy Bolter)"			"pts":25},
+		{"id":41, "name":"Snipers",						"pts":10},
 		{"id":31, "name":"Vindicator",						"pts":50},
 		{"id":32, "name":"2x Vindicator",					"pts":75}
 	],
 	"formationConstraints":[
 		{"max":1, "name":"Spacecraft", "from":[541,542]},
-		{"maxPercent":33, "name":"Thunderhawks, Navy & Titans", "from":[545,549,550,552,553,554,555]}
+		{"maxPercent":33.34, "name":"Thunderhawks, Navy & Titans", "from":[545,549,550,552,553,554,555]}
 	],
 	"upgradeConstraints":[
 		{"max":1, "name":"Transport", "from":[11,12]},
@@ -72,9 +73,11 @@
 		{"min":4, "max":4, "from":[24,25], "appliesTo":[538]},
 		{"max":1, "name":"Cmdr", "from":[15,16,17,18]},
 		{"max":1, "perArmy":true, "from":[18]},
-		{"max":2, "from":[21]},
+		{"max":2, "from":[20,21]},
+		{"max":4, "from":[26,28], "appliesTo":[534,539]},
+		{"max":6, "from":[26,28], "appliesTo":[543]},
 		{"max":1, "from":[22]},
-    {"min":4, "max":4, "from":[40,41], "appliesTo":[539]},
+   		{"max":4, "from":[41], "appliesTo":[539]},
 		{"max":2, "from":[23,27]},
 		{"max":1, "from":[31,32]}
 	]


### PR DESCRIPTION
Added choice for Dreadnought and Razorback's weapon configurations Added maximum Razorbacks to keep in line with the others. Reworked Snipers so they are chosen as characters like intended. Added ''plus transport''. Kept Rhinos and Drop Pods as lines for those that play it as part of force selection instead on how it is in the special rule. Changed 33% for one third.