### PR TITLE
Fix NetEA Ordo Xenos constraints

### DIFF
--- a/war/lists/INQ_ordo_xenos_NETEA.json
+++ b/war/lists/INQ_ordo_xenos_NETEA.json
@@ -244,10 +244,10 @@
     { "max": 1, "perArmy": true, "from": [ 3 ] },
     { "max": 1, "perArmy": true, "from": [ 10 ] },
     { "max": 1, "from": [ 3, 14, 15, 16 ], "name": "Commander" },
-    { "max": 5, "min": 5, "from": [ 12, 13 ], "appliesTo": [502] },
+    { "max": 5, "min": 5, "from": [ 13, 12 ], "appliesTo": [502] },
     { "max": 1, "from": [ 1 ] },
     { "max": 1, "from": [ 4 ] },
-    { "max": 1, "from": [ 6 ] },
+    { "max": 2, "from": [ 6 ] },
     { "max": 1, "from": [ 7 ] },
     { "max": 1, "from": [18,19]}
   ]


### PR DESCRIPTION
* Default Speeder units to Tornadoes
* Increase max Dreadnaughts to 2