### PR TITLE
Update IG_krieg_NETEA.json

### DIFF
--- a/war/lists/IG_krieg_NETEA.json
+++ b/war/lists/IG_krieg_NETEA.json
@@ -1,7 +1,7 @@
 {
 	"id":"Death Korps of Krieg",
-	"version":"NetEA DKoK 2.0",
-	"by":"Iron Bloke, Borka",
+	"version":"NetEA Tournament Pack (2024-02-12)",
+	"by":"Iron Bloke, Borka, last update 2024-07-14 by Abetillo",
 	"sections":[
 		{"name":"DEATH KORPS CORE COMPANIES", "formations":[
 			{ "id":501, "name":"Regimental HQ", "pts":400, "units":"Death Korps Supreme Commander, 19 Death Korps Infantry" , "upgrades":[102,107,105,108,109,111,114,121,122] },
@@ -10,24 +10,24 @@
 		]},
 		{"name":"SUPPORT FORMATIONS", "formations":[
 			{ "id":511, "name":"Grenadiers Platoon", "pts":225, "units":"8 Death Korps Grenadiers", "upgrades":[51,53] },
-			{ "id":512, "name":"Engineers Platoon", "pts":250, "units":"8  Death Korps Engineers, Hades Breaching Drill", "upgrades":[] },
-			{ "id":513, "name":"Tank Platoon", "pts":280, "upgrades":[] },
-			{ "id":514, "name":"Heavy Tank Platoon", "pts":175, "upgrades":[103,101] },
+			{ "id":512, "name":"Engineers Platoon", "pts":250, "units":"8  Death Korps Engineers, Hades Breaching Drill"},
+			{ "id":513, "name":"Tank Platoon", "pts":280},
+			{ "id":514, "name":"Heavy Tank Platoon", "pts":175},
 			{ "id":515, "name":"Light Support Battery", "pts":200, "upgrades":[34,35] },
 			{ "id":516, "name":"Heavy Support Battery", "pts":0, "upgrades":[46,47] },
-			{ "id":517, "name":"Self-Propelled Heavy Support", "pts":250, "units":"3 Bombards", "upgrades":[] },
-			{ "id":518, "name":"Super-heavy Tank Platoon", "pts":200, "upgrades":[] },
+			{ "id":517, "name":"Self-Propelled Heavy Support", "pts":250, "units":"3 Bombards"},
+			{ "id":518, "name":"Super-heavy Tank Platoon", "pts":200},
 			{ "id":519, "name":"Death Rider Scout Platoon", "pts":150, "units":"6 Death Korps Rough Riders (with 'scout' ability)", "upgrades":[] },
 			{ "id":520, "name":"Deathstrike Silo", "pts":250, "units":"Death Korps Deathstrike Missile Silo", "upgrades":[] },
 			{ "id":521, "name":"Artillery Support Company", "pts":600, "units":"9 Earthshaker Platforms", "upgrades":[37,38] },
-			{ "id":522, "name":"Super-heavy Tank Support Company", "pts":500, "upgrades":[] }
+			{ "id":522, "name":"Super-heavy Tank Support Company", "pts":500}
 		]},
 		{"name":"TRENCHWORKS", "formations":[
-			{ "id":526, "name":"Trenchworks", "pts":75, "units":"80cm of Trenches, 20cm of Razor Wire, 4 Bunkers", "upgrades":[] }
+			{ "id":526, "name":"Trenchworks", "pts":75, "units":"4 Bunkers and 80cm of Trenches"}
 		]},
 		{"name":"IMPERIAL NAVY", "formations":[
-			{ "id":531, "name":"Thunderbolt Fighters", "pts":150, "units":"2 Thunderbolts", "upgrades":[] },
-			{ "id":532, "name":"Marauder Bomber", "pts":150, "upgrades":[] }
+			{ "id":531, "name":"Thunderbolt Fighters", "pts":150, "units":"2 Thunderbolts"},
+			{ "id":532, "name":"Marauder Heavy Bomber", "pts":150}
 		]},
 		{"name":"TITAN LEGIONS", "formations":[
 			{ "id":536, "name":"Warlord Titan", "pts":850, "upgrades":[] },
@@ -52,29 +52,29 @@
 		{ "id":38, "name":"9 Gun Emplacements", "pts":0 },
 		{ "id":41, "name":"3 Hydra or Heavy Anti-Aircraft Platform", "pts":125 },
 		{ "id":43, "name":"3 Earthshaker Platform", "pts":200 },
-		{ "id":44, "name":"3 Medusa Platform", "pts":250 },
+		{ "id":44, "name":"3 Medusa Platform", "pts":275 },
 		{ "id":46, "name":"3 Trojans", "pts":25 },
 		{ "id":47, "name":"3 Gun Emplacements", "pts":0 },
 		{ "id":51, "name":"8 Centaurs", "pts":75 },
-		{ "id":53, "name":"Gorgon (with heavy bolters)", "pts":75 },
+		{ "id":53, "name":"Gorgon", "pts":75 },
 		{ "id":114, "name":"Fire Support Battery (6 Fire Support)", "pts":75 },
 		{ "id":111, "name":"Infantry Platoon (10 Death Korps Infantry)", "pts":175 },
-		{ "id":101, "name":"Hydra", "pts":50 },
+		
 		{ "id":103, "name":"Macharius", "pts":75 },
 		{ "id":104, "name":"Macharius Command Tank", "pts":0 },
-		{ "id":109, "name":"Heavy Tank (Macharius)", "pts":100 },
+		{ "id":109, "name":"Heavy Tank (Macharius)", "pts":125 },
 		{ "id":105, "name":"Hellhound Squadron (3 Hellhounds)", "pts":100},
 		{ "id":107, "name":"Siege Transports (2 Gorgons)", "pts":200 },
-		{ "id":108, "name":"Siege Transports (2 Gorgons with mortars)", "pts":225 },
+		{ "id":108, "name":"Siege Transports (2 Gorgons with Mortar characters)", "pts":225 },
 		{ "id":102, "name":"Tank Squadron (3 Leman Russ Variants)", "pts":140},
 		{ "id":121, "name":"Leman Russ Surcharge for Tank Squadron", "pts":20},
-		{ "id":122, "name":"Demolisher Surcharge for Tank Squadron", "pts":20}
+		{ "id":122, "name":"Leman Russ Demolisher Surcharge for Tank Squadron", "pts":20}
 	],
 	"formationConstraints":[
 		{"max":1, "perPoints":1500, "from":[503]},
-		{"maxPercent":33, "name":"Titans & Navy", "from":[531,532,536,537,538,539]},
-		{"max":2, "name":"Support Formations", "from":[511,512,513,514,515,516,517,518,519,520,521,522], "forEach":[501,502,503], "name2":"Company"},
-		{"max":1, "name":"Trenchworks", "from":[526], "forEach":[501,502,503], "name2":"Company"},
+		{"maxPercent":33.34, "name":"Imperial Ally formations", "from":[531,532,536,537,538,539]},
+		{"max":2, "name":"Support Formations", "from":[511,512,513,514,515,516,517,518,519,520,521,522], "forEach":[501,502,503], "name2":"Core Company"},
+		{"max":1, "name":"Trenchworks", "from":[526], "forEach":[501,502,503], "name2":"Core Company"},
 		{"max":1, "from":[520]},
 		{"max":1, "from":[501]}
 	],
@@ -84,7 +84,7 @@
 		{"min":1, "max":1, "from":[21,22,23,24], "appliesTo":[518]},
 		{"min":1, "max":1, "from":[31,32], "appliesTo":[515]},
 		{"min":1, "max":1, "from":[41,43,44], "appliesTo":[516]},
-		{"min":2, "max":3, "from":[103], "appliesTo":[514]},
+		{"min":2, "max":2, "from":[103], "appliesTo":[514]},
 		{"min":1, "max":1, "from":[104], "appliesTo":[514]},
 		{"max":1, "from":[14]},
 		{"max":1, "from":[114]},


### PR DESCRIPTION
- Removed Hydra tank from the list
- Removed Razorwire from the list
- Replaced 33% with one third
- Removed Macharius and Hydra tank upgrades from Macharius formation
- Updated cost of Macharius upgrade to +125
- Updated cost of Medusa platforms to 275
- Fixed name of Heavy Marauder
- Fixed name of single Gorgon upgrade
- Fixed name of Core Companies when talking about the amount of support formations and upgrades allowed
- Removed unused code
- Updated cost of Warlord Class Titan down to 825p.
- Reordered upgrades on Core Companies so its easier to read and find upgrades.
- Renamed the third to the name on the TP.
- Renamed Thunderbolts to the name on the TP.